### PR TITLE
Replace hard-coded GTM ID with Twig variable.

### DIFF
--- a/Resources/views/tagmanager.html.twig
+++ b/Resources/views/tagmanager.html.twig
@@ -6,7 +6,7 @@
 {% endif %}
 
 <noscript>
-	<iframe src="//www.googletagmanager.com/ns.html?id=GTM-P9GP7F" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+	<iframe src="//www.googletagmanager.com/ns.html?id={{ id }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Looks like this got missed; would only impact non-javascript users.
