### PR TITLE
Add EventListener to append Tag Manager Container automatically to HTML responses.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,10 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()->booleanNode('enabled');
         $rootNode->children()->scalarNode('id');
 
+        $rootNode->children()
+            ->scalarNode('appendTo')
+            ->defaultFalse();
+
         $rootNode->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()->scalarNode('id');
 
         $rootNode->children()
-            ->scalarNode('appendTo')
+            ->booleanNode('autoAppend')
             ->defaultFalse();
 
         $rootNode->end();

--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -1,0 +1,77 @@
+<?php
+namespace Xynnn\GoogleTagManagerBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Class GoogleTagManagerListener
+ *
+ * @package Xynnn\GoogleTagManagerBundle\EventListener
+ */
+class GoogleTagManagerListener
+{
+    private $twig;
+
+    private $appendTo;
+
+    public function __construct($serviceContainer, $appendTo)
+    {
+        $this->twig = $serviceContainer->get('twig');
+        $this->appendTo = $appendTo;
+    }
+
+    /**
+     * @param FilterResponseEvent $event
+     *
+     * @return bool
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $response = $event->getResponse();
+        $contentType = $response->headers->get('content-type');
+        $appendTo = strtolower($this->appendTo);
+
+        // not configured to append automatically
+        if ( ! in_array($appendTo, ['top', 'bottom'])) {
+            return false;
+        }
+
+        // only append to HTML responses
+        if ( ! in_array($contentType, ['text/html', null])) {
+            return false;
+        }
+
+        // render the GTM Twig template
+        $template = $this->twig
+            ->getExtension('google_tag_manager')
+            ->render($this->twig);
+
+        // decide where to append
+        switch ($appendTo)
+        {
+            case 'top':
+                $content = $this->appendTop($template, $response->getContent());
+                break;
+
+            case 'bottom':
+            default:
+                $content = $this->appendBottom($template, $response->getContent());
+                break;
+        }
+
+        // update the response
+        $response->setContent($content);
+
+        return true;
+    }
+
+    private function appendTop($snippet, $content)
+    {
+        return preg_replace('/<body\b[^>]*>/', "$0" . $snippet, $content, 1);
+    }
+
+    private function appendBottom($snippet, $content)
+    {
+        return str_replace('</body>', $snippet . '</body>', $content);
+    }
+}

--- a/Helper/GoogleTagManagerHelper.php
+++ b/Helper/GoogleTagManagerHelper.php
@@ -50,7 +50,7 @@ class GoogleTagManagerHelper extends Helper
     }
 
     /**
-     * @return bool
+     * @return string
      */
     public function getId()
     {

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ $manager->addData('example', 'value');
 google_tag_manager:
     enabled: true
     id: "GTM-XXXXXX"
+    appendTo: top|bottom
 ```
 
 ## Authors
@@ -96,5 +97,5 @@ google_tag_manager:
 + [twitter/pbraeutigam](http://twitter.com/pbraeutigam)
 
 ## License
-Copyright (c) 2015 Philipp Bräutigam  
+Copyright (c) 2015 Philipp Bräutigam
 This repository is released under the GNU LGPL v3.0 license.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $manager->addData('example', 'value');
 google_tag_manager:
     enabled: true
     id: "GTM-XXXXXX"
-    appendTo: top|bottom
+    autoAppend: true|false
 ```
 
 ## Authors

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,6 +22,6 @@ services:
 
     listener.google_tag_manager:
         class: Xynnn\GoogleTagManagerBundle\EventListener\GoogleTagManagerListener
-        arguments: ["@service_container", "%google_tag_manager.appendTo%"]
+        arguments: ["@service_container", "%google_tag_manager.autoAppend%"]
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -19,3 +19,9 @@ services:
         arguments: ["@templating.helper.google_tag_manager"]
         tags:
             - { name: "twig.extension" }
+
+    listener.google_tag_manager:
+        class: Xynnn\GoogleTagManagerBundle\EventListener\GoogleTagManagerListener
+        arguments: ["@service_container", "%google_tag_manager.appendTo%"]
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }


### PR DESCRIPTION
Hey @xyNNN, I created an EventListener so you don't have to explicitly call the Twig function in your templates.

I wanted to inject Twig directly into the listener, however phpunit was complaining about a non-existent service, so I ended up injecting the DI container. 

Your input / criticism on this is welcome.
