### PR TITLE
Allow complex data structures, not just strings

### DIFF
--- a/Resources/views/tagmanager.html.twig
+++ b/Resources/views/tagmanager.html.twig
@@ -1,7 +1,7 @@
 <!-- Google Tag Manager START -->
 {% if data is not null %}
 <script>
-	dataLayer = [{ {% for key, value in data %}'{{ key }}': '{{ value }}'{% if loop.last %}{% else %}, {% endif %}{% endfor %} }];
+	dataLayer = [{ {% for key, value in data %}'{{ key }}': {{ value|json_encode|raw }}{% if loop.last %}{% else %}, {% endif %}{% endfor %} }];
 </script>
 {% endif %}
 


### PR DESCRIPTION
Sometimes we want to pass complex data structures to the dataLayer, for example when using the enhanced e-commerce feature (https://developers.google.com/tag-manager/enhanced-ecommerce). With this PR, we can still just add simple strings if needed, so there is no BC break.
