### PR TITLE
Only append container in master request

### DIFF
--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -40,6 +40,11 @@ class GoogleTagManagerListener
             return false;
         }
 
+        // only append to master request
+        if ( ! $event->isMasterRequest()) {
+            return false;
+        }
+
         // render the GTM Twig template
         $template = $this->twig
             ->getExtension('google_tag_manager')


### PR DESCRIPTION
Previously, when rendering an exception, as the HttpKernel use a sub-request
to handle the exception, the container was injected twice, for the sub-request
and the master request.

I don't think this is a breaking change as appending the same container twice is always wrong.
