### PR TITLE
Split output for HEAD & for BODY (fixes #8)

### DIFF
--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Xynnn\GoogleTagManagerBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -10,14 +11,23 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  */
 class GoogleTagManagerListener
 {
+
     private $twig;
 
+    /**
+     * @var bool
+     */
     private $autoAppend;
 
+    /**
+     * GoogleTagManagerListener constructor.
+     * @param $serviceContainer
+     * @param $autoAppend
+     */
     public function __construct($serviceContainer, $autoAppend)
     {
         $this->twig = $serviceContainer->get('twig');
-        $this->autoAppend = (bool) $autoAppend;
+        $this->autoAppend = (bool)$autoAppend;
     }
 
     /**
@@ -28,33 +38,53 @@ class GoogleTagManagerListener
     public function onKernelResponse(FilterResponseEvent $event)
     {
         $response = $event->getResponse();
-        $contentType = $response->headers->get('content-type');
 
-        // not configured to append automatically
-        if ( ! $this->autoAppend) {
-            return false;
-        }
-
-        // only append to HTML responses
-        if ( ! in_array($contentType, ['text/html', null])) {
-            return false;
-        }
-
-        // only append to master request
-        if ( ! $event->isMasterRequest()) {
+        if (!$this->allowRender($event)) {
             return false;
         }
 
         // render the GTM Twig template
         $template = $this->twig
             ->getExtension('google_tag_manager')
-            ->render($this->twig);
+            ->render($this->twig, \Xynnn\GoogleTagManagerBundle\Extension\GoogleTagManagerExtension::AREA_HEAD);
+
+        // insert container immediately after opening <head>
+        $content = preg_replace('/<head\b[^>]*>/', "$0" . $template, $response->getContent(), 1);
+
+        // render the GTM Twig template for <noscript>
+        $template = $this->twig
+            ->getExtension('google_tag_manager')
+            ->render($this->twig, \Xynnn\GoogleTagManagerBundle\Extension\GoogleTagManagerExtension::AREA_BODY);
 
         // insert container immediately after opening <body>
         $content = preg_replace('/<body\b[^>]*>/', "$0" . $template, $response->getContent(), 1);
 
         // update the response
         $response->setContent($content);
+
+        return true;
+    }
+
+    /**
+     * @param FilterResponseEvent $event
+     * @return bool
+     */
+    private function allowRender(FilterResponseEvent $event)
+    {
+        // not configured to append automatically
+        if (!$this->autoAppend) {
+            return false;
+        }
+
+        // only append to HTML responses
+        if (!in_array($event->getResponse()->headers->get('content-type'), ['text/html', null])) {
+            return false;
+        }
+
+        // only append to master request
+        if (!$event->isMasterRequest()) {
+            return false;
+        }
 
         return true;
     }

--- a/Extension/GoogleTagManagerExtension.php
+++ b/Extension/GoogleTagManagerExtension.php
@@ -21,6 +21,10 @@ use Xynnn\GoogleTagManagerBundle\Helper\GoogleTagManagerHelper;
  */
 class GoogleTagManagerExtension extends Twig_Extension
 {
+    const AREA_FULL = 'full';
+    const AREA_HEAD = 'head';
+    const AREA_BODY = 'body';
+
     /** @var HelperInterface $helper */
     private $helper;
 
@@ -55,7 +59,7 @@ class GoogleTagManagerExtension extends Twig_Extension
      *
      * @return string
      */
-    public function render(\Twig_Environment $twig)
+    public function render(\Twig_Environment $twig, $area = self::AREA_FULL)
     {
         /** @var GoogleTagManagerHelper $helper */
         $helper = $this->getHelper();
@@ -64,8 +68,18 @@ class GoogleTagManagerExtension extends Twig_Extension
            return false;
         }
 
+        switch($area) {
+            case self::AREA_HEAD:
+                $template = 'tagmanager_head'; break;
+            case self::AREA_BODY:
+                $template = 'tagmanager_body'; break;
+            case self::AREA_FULL:
+            default:
+                $template = 'tagmanager'; break;
+        }
+
         return $twig->render(
-            'GoogleTagManagerBundle::tagmanager.html.twig', array(
+            'GoogleTagManagerBundle::' . $template . '.html.twig', array(
                 'id' => $helper->getId(),
                 'data' => $helper->hasData() ? $helper->getData() : null
             )

--- a/Helper/GoogleTagManagerHelper.php
+++ b/Helper/GoogleTagManagerHelper.php
@@ -18,18 +18,12 @@ use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
  *
  * @package Xynnn\GoogleTagManagerBundle\Helper
  */
-class GoogleTagManagerHelper extends Helper
+class GoogleTagManagerHelper extends Helper implements GoogleTagManagerHelperInterface
 {
-    /** @var GoogleTagManagerInterface $service */
-    private $service;
-
     /**
-     * @return GoogleTagManagerInterface
+     * @var GoogleTagManagerInterface
      */
-    private function getService()
-    {
-        return $this->service;
-    }
+    private $service;
 
     /**
      * @param GoogleTagManagerInterface $service
@@ -40,44 +34,40 @@ class GoogleTagManagerHelper extends Helper
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
      */
     public function isEnabled()
     {
-        $service = $this->getService();
-
-        return $service->isEnabled();
+        return $this->service->isEnabled();
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getId()
     {
-        $service = $this->getService();
-
-        return $service->getId();
+        return $this->service->getId();
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getData()
     {
-        $service = $this->getService();
-
-        return $service->getData();
+        return $this->service->getData();
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasData()
     {
-        return is_array($this->getData())
-            && count($this->getData()) > 0;
+        return $this->service->hasData();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'google_tag_manager';

--- a/Helper/GoogleTagManagerHelperInterface.php
+++ b/Helper/GoogleTagManagerHelperInterface.php
@@ -8,21 +8,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Xynnn\GoogleTagManagerBundle\Service;
+namespace Xynnn\GoogleTagManagerBundle\Helper;
+
+use Symfony\Component\Templating\Helper\Helper;
+use Symfony\Component\Templating\Helper\HelperInterface;
+use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 /**
- * Interface GoogleTagManagerInterface
+ * Interface GoogleTagManagerHelperInterface
  *
- * @package Xynnn\GoogleTagManagerBundle\Service
+ * @package Xynnn\GoogleTagManagerBundle\Helper
  */
-interface GoogleTagManagerInterface
+interface GoogleTagManagerHelperInterface extends HelperInterface
 {
-    /**
-     * @param $key
-     * @param $value
-     */
-    public function addData($key, $value);
-
     /**
      * @return bool
      */

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Please be aware to insert into right after the HTML body tag!
 
 ```html
 <body>
-{{ google_tag_manager('body') }}
+{{ google_tag_manager_body }}
 ...
 </body>
 ```
@@ -74,7 +74,7 @@ And right after the HTML head tag:
 
 ```html
 <head>
-{{ google_tag_manager('head') }}
+{{ google_tag_manager_head }}
 ...
 </head>
 ```

--- a/README.md
+++ b/README.md
@@ -65,10 +65,21 @@ Please be aware to insert into right after the HTML body tag!
 
 ```html
 <body>
-{{ google_tag_manager() }}
+{{ google_tag_manager('body') }}
 ...
 </body>
 ```
+
+And right after the HTML head tag:
+
+```html
+<head>
+{{ google_tag_manager('head') }}
+...
+</head>
+```
+
+Or use the `autoAppend` setting to let a kernel reponse listener add them to your layout automatically.
 
 ### Step 5: Fill up the DataLayer from Google Tag Manager (Optional)
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ And right after the HTML head tag:
 
 Or use the `autoAppend` setting to let a kernel reponse listener add them to your layout automatically.
 
+Additional instructions: https://developers.google.com/tag-manager/quickstart
+
 ### Step 5: Fill up the DataLayer from Google Tag Manager (Optional)
 
 If you want to send some information to the Google Tag Manager, you can use the dataLayer.
 
 ```php
-/** @var GoogleTagManager $manager */
+/** @var GoogleTagManagerInterface $manager */
 $manager = $this->get('google_tag_manager');
 $manager->addData('example', 'value');
 ```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,7 +15,7 @@ services:
             - { name: "templating.helper", alias: "google_tag_manager" }
 
     twig.extension.google_tag_manager:
-        class: Xynnn\GoogleTagManagerBundle\Extension\GoogleTagManagerExtension
+        class: Xynnn\GoogleTagManagerBundle\Twig\GoogleTagManagerExtension
         arguments: ["@templating.helper.google_tag_manager"]
         tags:
             - { name: "twig.extension" }

--- a/Resources/views/data.html.twig
+++ b/Resources/views/data.html.twig
@@ -1,0 +1,5 @@
+{% if data is not null %}
+    <script>
+        dataLayer = [{{ data|json_encode|raw }}];
+    </script>
+{% endif %}

--- a/Resources/views/tagmanager.html.twig
+++ b/Resources/views/tagmanager.html.twig
@@ -1,16 +1,2 @@
-<!-- Google Tag Manager START -->
-{% if data is not null %}
-<script>
-	dataLayer = [{{ data|json_encode|raw }}];
-</script>
-{% endif %}
-
-<noscript>
-	<iframe src="//www.googletagmanager.com/ns.html?id={{ id }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-</noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-			'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','{{ id }}');</script>
-<!-- Google Tag Manager END -->
+{% include 'tagmanager_head.html.twig' %}
+{% include 'tagmanager_noscript.html.twig' %}

--- a/Resources/views/tagmanager.html.twig
+++ b/Resources/views/tagmanager.html.twig
@@ -1,2 +1,2 @@
-{% include 'tagmanager_head.html.twig' %}
-{% include 'tagmanager_noscript.html.twig' %}
+{% include 'GoogleTagManagerBundle::tagmanager_head.html.twig' %}
+{% include 'GoogleTagManagerBundle::tagmanager_body.html.twig' %}

--- a/Resources/views/tagmanager_body.html.twig
+++ b/Resources/views/tagmanager_body.html.twig
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ id }}"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/Resources/views/tagmanager_head.html.twig
+++ b/Resources/views/tagmanager_head.html.twig
@@ -1,0 +1,9 @@
+{% include 'data.html.twig' %}
+
+<!-- Google Tag Manager  -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ id }}');</script>
+<!-- End Google Tag Manager -->

--- a/Resources/views/tagmanager_head.html.twig
+++ b/Resources/views/tagmanager_head.html.twig
@@ -1,4 +1,4 @@
-{% include 'data.html.twig' %}
+{% include 'GoogleTagManagerBundle::data.html.twig' %}
 
 <!-- Google Tag Manager  -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/Twig/GoogleTagManagerExtension.php
+++ b/Twig/GoogleTagManagerExtension.php
@@ -13,6 +13,7 @@ namespace Xynnn\GoogleTagManagerBundle\Twig;
 use Symfony\Component\Templating\Helper\HelperInterface;
 use Twig_Extension;
 use Xynnn\GoogleTagManagerBundle\Helper\GoogleTagManagerHelper;
+use Xynnn\GoogleTagManagerBundle\Helper\GoogleTagManagerHelperInterface;
 
 /**
  * Class GoogleTagManagerExtension
@@ -26,14 +27,14 @@ class GoogleTagManagerExtension extends Twig_Extension
     const AREA_BODY = 'body';
 
     /**
-     * @var HelperInterface
+     * @var GoogleTagManagerHelperInterface
      */
     private $helper;
 
     /**
-     * @param GoogleTagManagerHelper $helper
+     * @param GoogleTagManagerHelperInterface $helper
      */
-    public function __construct(HelperInterface $helper)
+    public function __construct(GoogleTagManagerHelperInterface $helper)
     {
         $this->helper = $helper;
     }
@@ -66,7 +67,6 @@ class GoogleTagManagerExtension extends Twig_Extension
      */
     public function render(\Twig_Environment $twig)
     {
-
         return $this->getRenderedTemplate($twig, self::AREA_FULL);
     }
 

--- a/Twig/GoogleTagManagerExtension.php
+++ b/Twig/GoogleTagManagerExtension.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Xynnn\GoogleTagManagerBundle\Extension;
+namespace Xynnn\GoogleTagManagerBundle\Twig;
 
 use Symfony\Component\Templating\Helper\HelperInterface;
 use Twig_Extension;

--- a/Twig/GoogleTagManagerExtension.php
+++ b/Twig/GoogleTagManagerExtension.php
@@ -47,21 +47,24 @@ class GoogleTagManagerExtension extends Twig_Extension
         return array(
             new \Twig_SimpleFunction('google_tag_manager', array($this, 'render'), array(
                 'is_safe' => array('html'),
-                'needs_environment' => true
+                'needs_environment' => true,
+                'deprecated' => true,
             )),
             new \Twig_SimpleFunction('google_tag_manager_body', array($this, 'renderBody'), array(
                 'is_safe' => array('html'),
-                'needs_environment' => true
+                'needs_environment' => true,
             )),
             new \Twig_SimpleFunction('google_tag_manager_head', array($this, 'renderHead'), array(
                 'is_safe' => array('html'),
-                'needs_environment' => true
+                'needs_environment' => true,
             )),
         );
     }
 
     /**
      * @param \Twig_Environment $twig
+     *
+     * @deprecated Use `renderHead` and `renderBody`
      *
      * @return string
      */


### PR DESCRIPTION
- [*] Splitted the twig helpers for HEAD & BODY, while keeping it backwards compatible so both get introduced together if still using the old helper (added deprecation on it).
- [*] Moved Extension to Twig folder, as Symfony docs suggest.
- [*] Added interface on Helper
- [*] Split views in sub views to load whatever appropriate but also easy to load all together
- [*] General improvements

@xyNNN I think it's ready for review. As far as I can see, it's still without BC breaks.