### PR TITLE
Add interface on GoogleTagManager service

### DIFF
--- a/Helper/GoogleTagManagerHelper.php
+++ b/Helper/GoogleTagManagerHelper.php
@@ -11,7 +11,7 @@
 namespace Xynnn\GoogleTagManagerBundle\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
-use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager;
+use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 /**
  * Class GoogleTagManagerHelper
@@ -20,11 +20,11 @@ use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager;
  */
 class GoogleTagManagerHelper extends Helper
 {
-    /** @var GoogleTagManager $service */
+    /** @var GoogleTagManagerInterface $service */
     private $service;
 
     /**
-     * @return GoogleTagManager
+     * @return GoogleTagManagerInterface
      */
     private function getService()
     {
@@ -32,9 +32,9 @@ class GoogleTagManagerHelper extends Helper
     }
 
     /**
-     * @param GoogleTagManager $service
+     * @param GoogleTagManagerInterface $service
      */
-    public function __construct(GoogleTagManager $service)
+    public function __construct(GoogleTagManagerInterface $service)
     {
         $this->service = $service;
     }

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -15,58 +15,22 @@ namespace Xynnn\GoogleTagManagerBundle\Service;
  *
  * @package Xynnn\GoogleTagManagerBundle\Service
  */
-class GoogleTagManager
+class GoogleTagManager implements GoogleTagManagerInterface
 {
-    /** @var bool $enabled */
+    /**
+     * @var bool
+     */
     private $enabled;
 
-    /** @var string $id */
+    /**
+     * @var string
+     */
     private $id;
 
-    /** @var array $data */
-    private $data;
-
     /**
-     * @param $key
-     * @param $value
+     * @var array
      */
-    public function addData($key, $value)
-    {
-        $this->data[$key] = $value;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEnabled()
-    {
-        return (bool) $this->enabled;
-    }
-
-    /**
-     * @return string
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * @return array
-     */
-    public function getData()
-    {
-        return $this->data;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasData()
-    {
-        return is_array($this->getData())
-        && count($this->getData()) > 0;
-    }
+    private $data = [];
 
     /**
      * @param $enabled
@@ -74,8 +38,48 @@ class GoogleTagManager
      */
     public function __construct($enabled, $id)
     {
-        $this->enabled = $enabled;
+        $this->enabled = (bool)$enabled;
         $this->id = $id;
-        $this->data = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addData($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasData()
+    {
+        return is_array($this->getData())
+        && count($this->getData()) > 0;
     }
 }

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -30,7 +30,7 @@ class GoogleTagManager implements GoogleTagManagerInterface
     /**
      * @var array
      */
-    private $data = [];
+    private $data = array();
 
     /**
      * @param $enabled

--- a/Service/GoogleTagManagerFactory.php
+++ b/Service/GoogleTagManagerFactory.php
@@ -30,6 +30,9 @@ class GoogleTagManagerFactory
         return $this->container;
     }
 
+    /**
+     * @return GoogleTagManagerInterface
+     */
     public function create()
     {
         $container = $this->getContainer();

--- a/Service/GoogleTagManagerInterface.php
+++ b/Service/GoogleTagManagerInterface.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * This file is part of the GoogleTagManagerBundle project
+ *
+ * (c) Philipp Braeutigam <philipp.braeutigam@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xynnn\GoogleTagManagerBundle\Service;
+
+/**
+ * Interface GoogleTagManagerInterface
+ *
+ * @package Xynnn\GoogleTagManagerBundle\Service
+ */
+interface GoogleTagManagerInterface
+{
+    /**
+     * @param $key
+     * @param $value
+     */
+    public function addData($key, $value);
+
+    /**
+     * @return bool
+     */
+    public function isEnabled();
+
+    /**
+     * @return string
+     */
+    public function getId();
+
+    /**
+     * @return array
+     */
+    public function getData();
+
+    /**
+     * @return bool
+     */
+    public function hasData();
+}


### PR DESCRIPTION
Allows to inject your own GoogleTagManager implementation somewhere by using an interface. Has to be used more often maybe, but it's a beginning.