### PR TITLE
Require symfony/templating as helper is depending on it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=5.3.2",
         "symfony/dependency-injection": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",
-        "symfony/config": "~2.8|~3.0"
+        "symfony/config": "~2.8|~3.0",
+        "symfony/templating": "~2.8|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit":  "~4.3"


### PR DESCRIPTION
The twig templating helper in the bundle depends on this component, but it's not required in composer.json. Makes development and strict dependency management better.