### PR TITLE
Add support for Scrutinizer CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,12 @@ before_script:
     - composer self-update
     - composer install
 
+script:
+    - vendor/bin/phpunit --coverage-clover coverage.clover --stderr --verbose
+
+after_script:
+    - wget https://scrutinizer-ci.com/ocular.phar
+    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
 notifications:
   email: philipp.braeutigam@googlemail.com

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Software License](https://img.shields.io/badge/license-LGPL%203.0-brightgreen.svg?style=flat-square)](LICENSE)
 [![Build Status](https://travis-ci.org/xyNNN/GoogleTagManagerBundle.svg?branch=master)](https://travis-ci.org/xyNNN/GoogleTagManagerBundle)
+[![Scrutinizer Quality Score](https://img.shields.io/scrutinizer/g/xyNNN/GoogleTagManagerBundle.svg)](https://scrutinizer-ci.com/g/xyNNN/GoogleTagManagerBundle)
 
 The GoogleTagManagerBundle provides you an easy-to-use method to integrate the Google Tag Manager into your Symfony 2 application.
 


### PR DESCRIPTION
Could you add the package on Scrutinizer (https://scrutinizer-ci.com/g/new) so we could report on code coverage? 

Code coverage instructions to enable from Travis: https://scrutinizer-ci.com/docs/tools/external-code-coverage/

It helps figuring out 'issues' and see code coverage, pushing more into testing biggest parts of the code.