### PR TITLE
Add 'setData' and 'mergeData' methods, deprecate 'addData' method

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to send some information to the Google Tag Manager, you can use the 
 ```php
 /** @var GoogleTagManagerInterface $manager */
 $manager = $this->get('google_tag_manager');
-$manager->addData('example', 'value');
+$manager->setData('example', 'value');
 ```
 
 ## Configuration

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -47,7 +47,28 @@ class GoogleTagManager implements GoogleTagManagerInterface
      */
     public function addData($key, $value)
     {
+        $this->setData($key, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData($key, $value)
+    {
         $this->data[$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mergeData($key, $value)
+    {
+        $merge = [];
+        if (array_key_exists($key, $this->data)) {
+            $merge = $this->data[$key];
+        }
+
+        $this->setData($key, array_merge($merge, $value));
     }
 
     /**

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -63,7 +63,7 @@ class GoogleTagManager implements GoogleTagManagerInterface
      */
     public function mergeData($key, $value)
     {
-        $merge = [];
+        $merge = array();
         if (array_key_exists($key, $this->data)) {
             $merge = $this->data[$key];
         }

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -68,7 +68,7 @@ class GoogleTagManager implements GoogleTagManagerInterface
             $merge = $this->data[$key];
         }
 
-        $this->setData($key, array_merge($merge, $value));
+        $this->setData($key, array_merge_recursive($merge, $value));
     }
 
     /**

--- a/Service/GoogleTagManagerInterface.php
+++ b/Service/GoogleTagManagerInterface.php
@@ -20,8 +20,23 @@ interface GoogleTagManagerInterface
     /**
      * @param $key
      * @param $value
+     * @deprecated Use 'setData' or 'mergeData' methods
      */
     public function addData($key, $value);
+
+    /**
+     * @param $key
+     * @param $value
+     * @return void
+     */
+    public function setData($key, $value);
+
+    /**
+     * @param $key
+     * @param $value
+     * @return void
+     */
+    public function mergeData($key, $value);
 
     /**
      * @return bool


### PR DESCRIPTION
I think it's good to have more granular control over how data is set to TagManager. Sometimes you simply want to override all (or set), sometimes you want the data to be merged if set from several locations in the request. I've deprecated the 'addData' method and introduced 'setData' for that (simply setting it, overwriting it). The old 'addData' method now simply calls the 'setData' method to not introduce BC.

Next to this, an 'mergeData' method is introduced, that does the merging option. You can keep your old data, and have it merged/overriden where necessary. Simply by using the 'array_merge_recursive' function.

I think this could be a 2.2 release, as it's a minor break by adding a method to the interface we currently use.