### PR TITLE
Add push methods (which output before closing body tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2.3.0](https://github.com/xyNNN/GoogleTagManagerBundle/tree/2.3.0) (2017-08-22)
+
+[Full Changelog](https://github.com/xyNNN/GoogleTagManagerBundle/compare/2.2.0...2.3.0)
+
+**Implemented enhancements:**
+
+- Add support to push data to dataLayer that should not be in initial dataLayer in HEAD
+- Will insert pushes to dataLayer variable at bottom of HTML output to not block rendering
+
+## [2.2.0](https://github.com/xyNNN/GoogleTagManagerBundle/tree/2.2.0) (2017-08-21)
+
+[Full Changelog](https://github.com/xyNNN/GoogleTagManagerBundle/compare/2.1.0...2.2.0)
+
+**Implemented enhancements:**
+
+- Support to merge variables set on multiple locations in code
+
 ## [2.1.0](https://github.com/xyNNN/GoogleTagManagerBundle/tree/2.1.0) (2017-05-03)
 
 [Full Changelog](https://github.com/xyNNN/GoogleTagManagerBundle/compare/2.0.1...2.1.0)

--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -54,13 +54,20 @@ class GoogleTagManagerListener
             ->getExtension('google_tag_manager')
             ->renderBody($this->twig);
 
+        // render pushes before </body>
+        $templateBeforeBodyEnd = $this->twig
+            ->getExtension('google_tag_manager')
+            ->renderBodyEnd($this->twig);
+
         // Insert container immediately after opening <head> or <body>
         $content = preg_replace(array(
             '/<head\b[^>]*>/',
-            '/<body\b[^>]*>/'
+            '/<body\b[^>]*>/',
+            '/<\/body\b[^>]*>/',
         ), array(
             "$0" . $templateHead,
-            "$0" . $templateBody
+            "$0" . $templateBody,
+            $templateBeforeBodyEnd . "$0"
         ), $response->getContent(), 1);
 
         // update the response

--- a/Helper/GoogleTagManagerHelper.php
+++ b/Helper/GoogleTagManagerHelper.php
@@ -68,6 +68,14 @@ class GoogleTagManagerHelper extends Helper implements GoogleTagManagerHelperInt
     /**
      * {@inheritdoc}
      */
+    public function getPush()
+    {
+        return $this->service->getPush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'google_tag_manager';

--- a/Helper/GoogleTagManagerHelperInterface.php
+++ b/Helper/GoogleTagManagerHelperInterface.php
@@ -40,4 +40,9 @@ interface GoogleTagManagerHelperInterface extends HelperInterface
      * @return bool
      */
     public function hasData();
+
+    /**
+     * @return array
+     */
+    public function getPush();
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Please be aware to insert into right after the HTML body tag!
 
 ```html
 <body>
-{{ google_tag_manager_body }}
+{{ google_tag_manager_body() }}
 ...
 </body>
 ```
@@ -76,7 +76,7 @@ And right after the HTML head tag:
 
 ```html
 <head>
-{{ google_tag_manager_head }}
+{{ google_tag_manager_head() }}
 ...
 </head>
 ```
@@ -84,7 +84,7 @@ And right after the HTML head tag:
 And right before the closing BODY tag:
 
 ```html
-{{ google_tag_manager_body_end }}
+{{ google_tag_manager_body_end() }}
 </body>
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ And right after the HTML head tag:
 </head>
 ```
 
+And right before the closing BODY tag:
+
+```html
+{{ google_tag_manager_body_end }}
+</body>
+```
+
 Or use the `autoAppend` setting to let a kernel reponse listener add them to your layout automatically.
 
 Additional instructions: https://developers.google.com/tag-manager/quickstart
@@ -93,6 +100,14 @@ If you want to send some information to the Google Tag Manager, you can use the 
 /** @var GoogleTagManagerInterface $manager */
 $manager = $this->get('google_tag_manager');
 $manager->setData('example', 'value');
+```
+
+And if you want to add pushes at the end of the body (not in initial dataLayer):
+
+```php
+/** @var GoogleTagManagerInterface $manager */
+$manager = $this->get('google_tag_manager');
+$manager->addPush(['test' => 123);
 ```
 
 ## Configuration

--- a/Resources/views/data.html.twig
+++ b/Resources/views/data.html.twig
@@ -1,9 +1,9 @@
-<script>
+<script type="text/javascript">
     window.dataLayer = window.dataLayer || [];
 </script>
 
 {% if data is not null %}
-    <script>
+    <script type="text/javascript">
         window.dataLayer.push({{ data|json_encode|raw }});
     </script>
 {% endif %}

--- a/Resources/views/data.html.twig
+++ b/Resources/views/data.html.twig
@@ -1,9 +1,6 @@
 <script type="text/javascript">
     window.dataLayer = window.dataLayer || [];
-</script>
-
-{% if data is not null %}
-    <script type="text/javascript">
+    {% if data is not null %}
         window.dataLayer.push({{ data|json_encode|raw }});
-    </script>
-{% endif %}
+    {% endif %}
+</script>

--- a/Resources/views/data.html.twig
+++ b/Resources/views/data.html.twig
@@ -1,6 +1,9 @@
+<script>
+    window.dataLayer = window.dataLayer || [];
+</script>
+
 {% if data is not null %}
     <script>
-        window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({{ data|json_encode|raw }});
     </script>
 {% endif %}

--- a/Resources/views/data.html.twig
+++ b/Resources/views/data.html.twig
@@ -1,5 +1,6 @@
 {% if data is not null %}
     <script>
-        dataLayer = [{{ data|json_encode|raw }}];
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({{ data|json_encode|raw }});
     </script>
 {% endif %}

--- a/Resources/views/tagmanager_body_end.html.twig
+++ b/Resources/views/tagmanager_body_end.html.twig
@@ -1,0 +1,7 @@
+{% if push is not null %}
+    {% for val in push %}
+        <script type="text/javascript">
+            window.dataLayer.push({{ val|json_encode|raw }});
+        </script>
+    {% endfor %}
+{% endif %}

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -33,6 +33,11 @@ class GoogleTagManager implements GoogleTagManagerInterface
     private $data = array();
 
     /**
+     * @var array
+     */
+    private $push = array();
+
+    /**
      * @param $enabled
      * @param $id
      */
@@ -93,6 +98,22 @@ class GoogleTagManager implements GoogleTagManagerInterface
     public function getData()
     {
         return $this->data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addPush($value)
+    {
+        $this->push[] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPush()
+    {
+        return $this->push;
     }
 
     /**

--- a/Service/GoogleTagManagerInterface.php
+++ b/Service/GoogleTagManagerInterface.php
@@ -57,4 +57,15 @@ interface GoogleTagManagerInterface
      * @return bool
      */
     public function hasData();
+
+    /**
+     * @return array
+     */
+    public function getPush();
+
+    /**
+     * @param $value
+     * @return void
+     */
+    public function addPush($value);
 }

--- a/Twig/GoogleTagManagerExtension.php
+++ b/Twig/GoogleTagManagerExtension.php
@@ -25,6 +25,7 @@ class GoogleTagManagerExtension extends Twig_Extension
     const AREA_FULL = 'full';
     const AREA_HEAD = 'head';
     const AREA_BODY = 'body';
+    const AREA_BODY_END = 'body_end';
 
     /**
      * @var GoogleTagManagerHelperInterface
@@ -55,6 +56,10 @@ class GoogleTagManagerExtension extends Twig_Extension
                 'needs_environment' => true,
             )),
             new \Twig_SimpleFunction('google_tag_manager_head', array($this, 'renderHead'), array(
+                'is_safe' => array('html'),
+                'needs_environment' => true,
+            )),
+            new \Twig_SimpleFunction('google_tag_manager_body_end', array($this, 'renderBodyEnd'), array(
                 'is_safe' => array('html'),
                 'needs_environment' => true,
             )),
@@ -94,6 +99,16 @@ class GoogleTagManagerExtension extends Twig_Extension
     }
 
     /**
+     * @param \Twig_Environment $twig
+     *
+     * @return string
+     */
+    public function renderBodyEnd(\Twig_Environment $twig)
+    {
+        return $this->getRenderedTemplate($twig, self::AREA_BODY_END);
+    }
+
+    /**
      * @return string
      */
     public function getName()
@@ -112,6 +127,8 @@ class GoogleTagManagerExtension extends Twig_Extension
                 return 'tagmanager_head';
             case self::AREA_BODY:
                 return 'tagmanager_body';
+            case self::AREA_BODY_END:
+                return 'tagmanager_body_end';
             case self::AREA_FULL:
             default:
                 return 'tagmanager';
@@ -132,7 +149,8 @@ class GoogleTagManagerExtension extends Twig_Extension
         return $twig->render(
             'GoogleTagManagerBundle::' . $this->getTemplate($area) . '.html.twig', array(
                 'id' => $this->helper->getId(),
-                'data' => $this->helper->hasData() ? $this->helper->getData() : null
+                'data' => $this->helper->hasData() ? $this->helper->getData() : null,
+                'push' => $this->helper->getPush() ? $this->helper->getPush() : null,
             )
         );
     }


### PR DESCRIPTION
I think this makes a 2.3 release. (Added it in changelog already).

It adds support to push objects along the road, which get separately outputted before the closing body tag. My use case was that I was adding multiple data points for ecommerce in it, which were conflicting in the dataLayer in the HEAD. Only my transaction had to be there, additional data had to be after loading GTM. Therefore I have added this feature - which gives total control on everything. 