### PR TITLE
Make getRenderedTemplate always return a string (not bool)

### DIFF
--- a/Twig/GoogleTagManagerExtension.php
+++ b/Twig/GoogleTagManagerExtension.php
@@ -143,7 +143,7 @@ class GoogleTagManagerExtension extends Twig_Extension
     private function getRenderedTemplate(\Twig_Environment $twig, $area)
     {
         if (!$this->helper->isEnabled()) {
-            return false;
+            return '';
         }
 
         return $twig->render(


### PR DESCRIPTION
To make it compatible with the return type specified in the phpdoc and the phpdoc of the methods using this method.