### PR TITLE
Add state resetting at the end of the request

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,6 +9,8 @@ services:
         public: true
         class: Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager
         factory: ["@google_tag_manager.factory", create]
+        tags:
+            - { name: "kernel.reset", method: "reset" }
 
     templating.helper.google_tag_manager:
         public: false

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -124,4 +124,13 @@ class GoogleTagManager implements GoogleTagManagerInterface
         return is_array($this->getData())
         && count($this->getData()) > 0;
     }
+
+    /**
+     * Reset internal state at the end of the request
+     */
+    public function reset()
+    {
+        $this->data = array();
+        $this->push = array();
+    }
 }


### PR DESCRIPTION
When using this plugin with https://github.com/php-pm/php-pm the events are added multiple times because they are saved internally and carried over to the next request. This PR fixes this by using Symfony's kernel.reset tag that is designed for this purpose.