### PR TITLE
fix tree builder usage unsupported by Symfony 5 (no root node)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,8 +25,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('google_tag_manager');
+        $treeBuilder = new TreeBuilder('google_tag_manager');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('google_tag_manager');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixing two deprecation warnings:
- A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
- The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "google_tag_manager" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.