### PR TITLE
Fix code-level breaking changes for Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
   - nightly
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
   - nightly
 
 sudo: false

--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -2,7 +2,6 @@
 
 namespace Xynnn\GoogleTagManagerBundle\EventListener;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Xynnn\GoogleTagManagerBundle\Twig\GoogleTagManagerExtension;
 
 /**

--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -3,7 +3,6 @@
 namespace Xynnn\GoogleTagManagerBundle\EventListener;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Xynnn\GoogleTagManagerBundle\Twig\GoogleTagManagerExtension;
 
 /**
@@ -41,11 +40,11 @@ class GoogleTagManagerListener
     }
 
     /**
-     * @param FilterResponseEvent $event
+     * @param mixed $event FilterResponseEvent before Symfony 5 and ResponseEvent afterwards
      *
      * @return bool
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse($event)
     {
         if (!$this->allowRender($event)) {
             return false;
@@ -80,11 +79,11 @@ class GoogleTagManagerListener
     }
 
     /**
-     * @param FilterResponseEvent $event
+     * @param mixed $event FilterResponseEvent before Symfony 5 and ResponseEvent afterwards
      *
      * @return bool
      */
-    private function allowRender(FilterResponseEvent $event)
+    private function allowRender($event)
     {
         // not configured to append automatically
         if (!$this->autoAppend) {

--- a/Helper/GoogleTagManagerHelperInterface.php
+++ b/Helper/GoogleTagManagerHelperInterface.php
@@ -10,9 +10,7 @@
 
 namespace Xynnn\GoogleTagManagerBundle\Helper;
 
-use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Templating\Helper\HelperInterface;
-use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 /**
  * Interface GoogleTagManagerHelperInterface

--- a/Tests/DependencyInjection/AbstractGoogleTagManagerExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractGoogleTagManagerExtensionTest.php
@@ -32,7 +32,7 @@ abstract class AbstractGoogleTagManagerExtensionTest extends PHPUnit_Framework_T
         $this->extension = new GoogleTagManagerExtension();
 
         $this->container = new ContainerBuilder();
-        $this->container->register('twig', $this->getMockBuilder('\Twig_Environment')->getMock());
+        $this->container->register('twig', $this->getMockBuilder('\Twig_Environment')->disableOriginalConstructor()->getMock());
         $this->container->registerExtension($this->extension);
     }
 

--- a/Twig/GoogleTagManagerExtension.php
+++ b/Twig/GoogleTagManagerExtension.php
@@ -10,9 +10,7 @@
 
 namespace Xynnn\GoogleTagManagerBundle\Twig;
 
-use Symfony\Component\Templating\Helper\HelperInterface;
 use Twig_Extension;
-use Xynnn\GoogleTagManagerBundle\Helper\GoogleTagManagerHelper;
 use Xynnn\GoogleTagManagerBundle\Helper\GoogleTagManagerHelperInterface;
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         "symfony/dependency-injection": "~2.8|~3.0|~4.0|~5.0",
         "symfony/http-kernel": "~2.8|~3.0|~4.0|~5.0",
         "symfony/config": "~2.8|~3.0|~4.0|~5.0",
-        "symfony/templating": "~2.8|~3.0|~4.0|~5.0"
+        "symfony/templating": "~2.8|~3.0|~4.0|~5.0",
+        "twig/twig": "~1.23|~2.0"
+    },
+    "conflict": {
+        "twig/twig": ">=3.0"
     },
     "require-dev": {
         "phpunit/phpunit":  "~4.3"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0|~5.0",
         "symfony/http-kernel": "~2.8|~3.0|~4.0|~5.0",
         "symfony/config": "~2.8|~3.0|~4.0|~5.0",


### PR DESCRIPTION
Hello!

I've tested the new version of the bundle on a real Symfony 5 project and there were some issues.

1. Commit 121783c. In Symfony code base some deprecated event classes were removed in Symfony 5 @see https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching. Their API contract used by the bundle didn't change, some just removing type hint is enough to fix it without breaking support for older Symfony versions.

2. Commit 6c8a1d8. The bundle is incompatible with Twig >=3.0 because of usage of Twig_Extension, Twig_SimpleFunction and Twig_Environment classes.  @see https://twig.symfony.com/doc/1.x/deprecated.html. The fix is simple but it will make the bundle incompatible for Twig 1 users. I've explicitly set Twig compatibility equal to the one of Symfony 2.8 and incompatible with Twig >=3.0.

3. Commit 7e7ba8d. The bundle uses php traits that were introduced in php 5.4, so I adjusted the dependency accordingly.

4. There were some unused imports.