### PR TITLE
Allow changing GoogleTagManager service status and id after init

### DIFF
--- a/Helper/GoogleTagManagerHelper.php
+++ b/Helper/GoogleTagManagerHelper.php
@@ -36,6 +36,14 @@ class GoogleTagManagerHelper extends Helper implements GoogleTagManagerHelperInt
     /**
      * {@inheritdoc}
      */
+    public function setEnabledStatus($status)
+    {
+        $this->service->setEnabledStatus($status);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isEnabled()
     {
         return $this->service->isEnabled();
@@ -47,6 +55,14 @@ class GoogleTagManagerHelper extends Helper implements GoogleTagManagerHelperInt
     public function getId()
     {
         return $this->service->getId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setId($id)
+    {
+        $this->service->setId($id);
     }
 
     /**

--- a/Helper/GoogleTagManagerHelper.php
+++ b/Helper/GoogleTagManagerHelper.php
@@ -36,9 +36,17 @@ class GoogleTagManagerHelper extends Helper implements GoogleTagManagerHelperInt
     /**
      * {@inheritdoc}
      */
-    public function setEnabledStatus($status)
+    public function enable()
     {
-        $this->service->setEnabledStatus($status);
+        $this->service->enable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disable()
+    {
+        $this->service->disable();
     }
 
     /**

--- a/Helper/GoogleTagManagerHelperInterface.php
+++ b/Helper/GoogleTagManagerHelperInterface.php
@@ -20,10 +20,14 @@ use Symfony\Component\Templating\Helper\HelperInterface;
 interface GoogleTagManagerHelperInterface extends HelperInterface
 {
     /**
-     * @param bool $status
      * @return void
      */
-    public function setEnabledStatus($status);
+    public function enable();
+
+    /**
+     * @return void
+     */
+    public function disable();
 
     /**
      * @return bool

--- a/Helper/GoogleTagManagerHelperInterface.php
+++ b/Helper/GoogleTagManagerHelperInterface.php
@@ -20,6 +20,12 @@ use Symfony\Component\Templating\Helper\HelperInterface;
 interface GoogleTagManagerHelperInterface extends HelperInterface
 {
     /**
+     * @param bool $status
+     * @return void
+     */
+    public function setEnabledStatus($status);
+
+    /**
      * @return bool
      */
     public function isEnabled();
@@ -28,6 +34,12 @@ interface GoogleTagManagerHelperInterface extends HelperInterface
      * @return string
      */
     public function getId();
+
+    /**
+     * @param string $id
+     * @return void
+     */
+    public function setId($id);
 
     /**
      * @return array

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -79,9 +79,17 @@ class GoogleTagManager implements GoogleTagManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function setEnabledStatus($status)
+    public function enable()
     {
-        $this->enabled = $status;
+        $this->enabled = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disable()
+    {
+        $this->enabled = false;
     }
 
     /**

--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -79,6 +79,14 @@ class GoogleTagManager implements GoogleTagManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function setEnabledStatus($status)
+    {
+        $this->enabled = $status;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isEnabled()
     {
         return $this->enabled;
@@ -90,6 +98,14 @@ class GoogleTagManager implements GoogleTagManagerInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
     }
 
     /**

--- a/Service/GoogleTagManagerInterface.php
+++ b/Service/GoogleTagManagerInterface.php
@@ -39,6 +39,12 @@ interface GoogleTagManagerInterface
     public function mergeData($key, $value);
 
     /**
+     * @param bool $status
+     * @return void
+     */
+    public function setEnabledStatus($status);
+
+    /**
      * @return bool
      */
     public function isEnabled();
@@ -47,6 +53,12 @@ interface GoogleTagManagerInterface
      * @return string
      */
     public function getId();
+
+    /**
+     * @param string $id
+     * @return void
+     */
+    public function setId($id);
 
     /**
      * @return array

--- a/Service/GoogleTagManagerInterface.php
+++ b/Service/GoogleTagManagerInterface.php
@@ -39,10 +39,14 @@ interface GoogleTagManagerInterface
     public function mergeData($key, $value);
 
     /**
-     * @param bool $status
      * @return void
      */
-    public function setEnabledStatus($status);
+    public function enable();
+
+    /**
+     * @return void
+     */
+    public function disable();
 
     /**
      * @return bool


### PR DESCRIPTION
Allow changing GoogleTagManager service status and id after initialization
This allows us to :
- Support enabling/disabling gtm service by page in same website
- Support injecting different gtm id by page in same website
- Handle multiple gtm id for one website