### PR TITLE
Fix autoescaping of & in url_suffix

### DIFF
--- a/Resources/views/tagmanager_body.html.twig
+++ b/Resources/views/tagmanager_body.html.twig
@@ -1,4 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ id }}{{ url_suffix }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ id }}{{ url_suffix|raw }}"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/Resources/views/tagmanager_head.html.twig
+++ b/Resources/views/tagmanager_head.html.twig
@@ -4,6 +4,6 @@
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{ url_suffix }}';f.parentNode.insertBefore(j,f);
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{ url_suffix|raw }}';f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','{{ id }}');</script>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
Additional parameters are rendered using entities which leads to GTM ignoring them. Autoescaping is suppressed by RAW filter.