### PR TITLE
minor fix

### DIFF
--- a/Service/GoogleTagManager.php
+++ b/Service/GoogleTagManager.php
@@ -25,7 +25,7 @@ class GoogleTagManager implements GoogleTagManagerInterface
 
     private array $push = array();
 
-    private string $additionalParameters;
+    private string $additionalParameters = '';
 
     public function __construct(bool $enabled, string $id)
     {


### PR DESCRIPTION
I got the error "Typed property must not be accessed before initialization" which was fixed by setting `additionalParameters = ''`