### PR TITLE
fix: undefined method isMasterRequest on Symfony >= 5

### DIFF
--- a/EventListener/GoogleTagManagerListener.php
+++ b/EventListener/GoogleTagManagerListener.php
@@ -95,8 +95,13 @@ class GoogleTagManagerListener
             return false;
         }
 
-        // only append to master request
-        if (!$event->isMasterRequest()) {
+        // only append to main request (symfony >= 5)
+        if ($event instanceof \Symfony\Component\HttpKernel\Event\ResponseEvent && !$event->isMainRequest()) {
+            return false;
+        }
+
+        // only append to master request (symfony < 5)
+        if ($event instanceof \Symfony\Component\HttpKernel\Event\FilterResponseEvent && !$event->isMasterRequest()) {
             return false;
         }
 


### PR DESCRIPTION
Hi,
This PR fix the following error that occurs on Symfony 5+ that use `ResponseEvent` instead of `FilterResponseEvent`
```
Attempted to call an undefined method named "isMasterRequest" of class "Symfony\Component\HttpKernel\Event\ResponseEvent".
Did you mean to call "isMainRequest"?
```